### PR TITLE
clang compilation flag fix, wss logging fix for close function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ CC		= gcc
 # Detect macOS and conditionally exclude GCC-specific flags
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	# macOS uses Clang even when gcc is called, so exclude GCC-specific flags
-	CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+# macOS uses Clang even when gcc is called, so exclude GCC-specific flags
+CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
 else
-	# Non-macOS systems (Linux, etc.) with real GCC
-	CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+# Non-macOS systems (Linux, etc.) with real GCC
+CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
 endif
 EXE		= wss
 LIBNAME = libwss

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,10 @@
 CC		= gcc
 
 # Detect macOS and conditionally exclude GCC-specific flags
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-# macOS uses Clang even when gcc is called, so exclude GCC-specific flags
-CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
-else
-# Non-macOS systems (Linux, etc.) with real GCC
-CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
-endif
+# Use shell-based conditional for better portability across make variants
+CFLAGS_COMMON = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+CFLAGS_GCC_SPECIFIC = -Wmaybe-uninitialized
+CFLAGS = $(CFLAGS_COMMON) $(shell if [ "`uname -s`" != "Darwin" ]; then echo "$(CFLAGS_GCC_SPECIFIC)"; fi)
 EXE		= wss
 LIBNAME = libwss
 RM		= rm -f

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ CC		= gcc
 # Detect macOS and conditionally exclude GCC-specific flags
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-# macOS uses Clang even when gcc is called, so exclude GCC-specific flags
-CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+	# macOS uses Clang even when gcc is called, so exclude GCC-specific flags
+	CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
 else
-# Non-macOS systems (Linux, etc.) with real GCC
-CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+	# Non-macOS systems (Linux, etc.) with real GCC
+	CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
 endif
 EXE		= wss
 LIBNAME = libwss

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ CC		= gcc
 # Detect macOS and conditionally exclude GCC-specific flags
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    # macOS uses Clang even when gcc is called, so exclude GCC-specific flags
-    CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+# macOS uses Clang even when gcc is called, so exclude GCC-specific flags
+CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
 else
-    # Non-macOS systems (Linux, etc.) with real GCC
-    CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+# Non-macOS systems (Linux, etc.) with real GCC
+CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
 endif
 EXE		= wss
 LIBNAME = libwss

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,16 @@
 #
 
 CC		= gcc
-CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+
+# Detect macOS and conditionally exclude GCC-specific flags
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    # macOS uses Clang even when gcc is called, so exclude GCC-specific flags
+    CFLAGS = -Wall -Werror -Wunused -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+else
+    # Non-macOS systems (Linux, etc.) with real GCC
+    CFLAGS = -Wall -Werror -Wunused -Wextra -Wmaybe-uninitialized -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wnull-dereference -Wformat=2 -Wshadow -Wsizeof-pointer-memaccess -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -fwrapv -fPIC -D_FORTIFY_SOURCE=2
+endif
 EXE		= wss
 LIBNAME = libwss
 RM		= rm -f

--- a/wss.c
+++ b/wss.c
@@ -609,29 +609,29 @@ int wss_error_code(struct wss_client *client)
 
 int wss_close(struct wss_client *client, int code)
 {
-    char buf[2];
-    unsigned short int *status;
+	char buf[2];
+	unsigned short int *status;
 
-    /* log if the close code is not valid per RFC 6455 §7.4.1 */
-    switch (code) {
-        case WS_CLOSE_NORMAL:            // 1000 - normal closure
-        case WS_CLOSE_GOING_AWAY:        // 1001 - going away
-        case WS_CLOSE_PROTOCOL_ERROR:    // 1002 - protocol error
-        case WS_CLOSE_UNACCEPTABLE_TYPE: // 1003 - unsupported data
-        case WS_CLOSE_DATA_INCONSISTENT: // 1007 - invalid data
-        case WS_CLOSE_POLICY_VIOLATION:  // 1008 - policy violation
-        case WS_CLOSE_LARGE_PAYLOAD:     // 1009 - message too big
-        case WS_CLOSE_EXTENSIONS:        // 1010 - required extension missing
-        case WS_CLOSE_UNEXPECTED:        // 1011 - internal server error
-            break; // valid
-        default:
-            wss_log(WS_LOG_ERROR, "Invalid WebSocket close status code: %d\n", code);
-            return -1;
-    }
+	/* log if the close code is not valid per RFC 6455 §7.4.1 */
+	switch (code) {
+		case WS_CLOSE_NORMAL:            // 1000 - normal closure
+		case WS_CLOSE_GOING_AWAY:        // 1001 - going away
+		case WS_CLOSE_PROTOCOL_ERROR:    // 1002 - protocol error
+		case WS_CLOSE_UNACCEPTABLE_TYPE: // 1003 - unsupported data
+		case WS_CLOSE_DATA_INCONSISTENT: // 1007 - invalid data
+		case WS_CLOSE_POLICY_VIOLATION:  // 1008 - policy violation
+		case WS_CLOSE_LARGE_PAYLOAD:     // 1009 - message too big
+		case WS_CLOSE_EXTENSIONS:        // 1010 - required extension missing
+		case WS_CLOSE_UNEXPECTED:        // 1011 - internal server error
+			break; // valid
+		default:
+			wss_log(WS_LOG_ERROR, "Invalid WebSocket close status code: %d\n", code);
+			return -1;
+	}
 
-    status = (unsigned short int *) buf;
-    *status = htons(code);
-    return wss_write(client, WS_OPCODE_CLOSE, buf, 2);
+	status = (unsigned short int *) buf;
+	*status = htons(code);
+	return wss_write(client, WS_OPCODE_CLOSE, buf, 2);
 }
 
 int wss_close_code(struct wss_frame *frame)

--- a/wss.c
+++ b/wss.c
@@ -609,15 +609,29 @@ int wss_error_code(struct wss_client *client)
 
 int wss_close(struct wss_client *client, int code)
 {
-	char buf[2];
-	unsigned short int *status;
-	if (code < 1000 && code > 1011 && code != 1015) {
-		wss_log(WS_LOG_ERROR, "Invalid WebSocket close status code: %d\n", code);
-		return -1;
-	}
-	status = (unsigned short int *) buf;
-	*status = htons(code);
-	return wss_write(client, WS_OPCODE_CLOSE, buf, 2);
+    char buf[2];
+    unsigned short int *status;
+
+    // log if the close code is not valid per RFC 6455 §7.4.1
+    switch (code) {
+        case WS_CLOSE_NORMAL:            // 1000 - normal closure
+        case WS_CLOSE_GOING_AWAY:        // 1001 - going away
+        case WS_CLOSE_PROTOCOL_ERROR:    // 1002 - protocol error
+        case WS_CLOSE_UNACCEPTABLE_TYPE: // 1003 - unsupported data
+        case WS_CLOSE_DATA_INCONSISTENT: // 1007 - invalid data
+        case WS_CLOSE_POLICY_VIOLATION:  // 1008 - policy violation
+        case WS_CLOSE_LARGE_PAYLOAD:     // 1009 - message too big
+        case WS_CLOSE_EXTENSIONS:        // 1010 - required extension missing
+        case WS_CLOSE_UNEXPECTED:        // 1011 - internal server error
+            break; // valid
+        default:
+            wss_log(WS_LOG_ERROR, "Invalid WebSocket close status code: %d\n", code);
+            return -1;
+    }
+
+    status = (unsigned short int *) buf;
+    *status = htons(code);
+    return wss_write(client, WS_OPCODE_CLOSE, buf, 2);
 }
 
 int wss_close_code(struct wss_frame *frame)

--- a/wss.c
+++ b/wss.c
@@ -614,16 +614,16 @@ int wss_close(struct wss_client *client, int code)
 
 	/* log if the close code is not valid per RFC 6455 §7.4.1 */
 	switch (code) {
-		case WS_CLOSE_NORMAL:            // 1000 - normal closure
-		case WS_CLOSE_GOING_AWAY:        // 1001 - going away
-		case WS_CLOSE_PROTOCOL_ERROR:    // 1002 - protocol error
-		case WS_CLOSE_UNACCEPTABLE_TYPE: // 1003 - unsupported data
-		case WS_CLOSE_DATA_INCONSISTENT: // 1007 - invalid data
-		case WS_CLOSE_POLICY_VIOLATION:  // 1008 - policy violation
-		case WS_CLOSE_LARGE_PAYLOAD:     // 1009 - message too big
-		case WS_CLOSE_EXTENSIONS:        // 1010 - required extension missing
-		case WS_CLOSE_UNEXPECTED:        // 1011 - internal server error
-			break; // valid
+		case WS_CLOSE_NORMAL:            /* 1000 - normal closure */
+		case WS_CLOSE_GOING_AWAY:        /* 1001 - going away */
+		case WS_CLOSE_PROTOCOL_ERROR:    /* 1002 - protocol error */
+		case WS_CLOSE_UNACCEPTABLE_TYPE: /* 1003 - unsupported data */
+		case WS_CLOSE_DATA_INCONSISTENT: /* 1007 - invalid data */
+		case WS_CLOSE_POLICY_VIOLATION:  /* 1008 - policy violation */
+		case WS_CLOSE_LARGE_PAYLOAD:     /* 1009 - message too big */
+		case WS_CLOSE_EXTENSIONS:        /* 1010 - required extension missing */
+		case WS_CLOSE_UNEXPECTED:        /* 1011 - internal server error */
+			break;
 		default:
 			wss_log(WS_LOG_ERROR, "Invalid WebSocket close status code: %d\n", code);
 			return -1;

--- a/wss.c
+++ b/wss.c
@@ -612,7 +612,7 @@ int wss_close(struct wss_client *client, int code)
     char buf[2];
     unsigned short int *status;
 
-    // log if the close code is not valid per RFC 6455 §7.4.1
+    /* log if the close code is not valid per RFC 6455 §7.4.1 */
     switch (code) {
         case WS_CLOSE_NORMAL:            // 1000 - normal closure
         case WS_CLOSE_GOING_AWAY:        // 1001 - going away


### PR DESCRIPTION
- fix-up clang/macos compilation; it was failing due to a flag that doesn't exist in clang  
- fix up a minor logging logic error in the wss close code

I'm not a makefile expert to let me know if there's a better way to address the clang issue